### PR TITLE
Improve docs and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+output/
+cache/
+app.log
+venv/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project converts any file into a video using Reed-Solomon error correction,
 - Supports GPU acceleration using CUDA.
 - Adjustable parameters for video resolution, frame rate, and error correction percentage.
 - Detailed progress logging.
+- Direct AVI output for high-speed, uncompressed recording using `AviDirectWriter`.
 
 ## Requirements
 
@@ -40,6 +41,31 @@ This project converts any file into a video using Reed-Solomon error correction,
      ```bash
      pip install cupy-cudaXXX  # Replace XXX with your CUDA version, e.g., cupy-cuda112 for CUDA 11.2
      ```
+
+## Quick Start
+
+After installing the dependencies you can launch the web interface with:
+
+```bash
+python main.py
+```
+
+Open your browser and navigate to [http://127.0.0.1:8080](http://127.0.0.1:8080) to start converting files.
+
+### Direct AVI Output
+
+For maximum performance you can write frames directly to an AVI container using `AviDirectWriter`:
+
+```python
+from converter import AviDirectWriter
+
+writer = AviDirectWriter(width=1920, height=1080, fps=30, output_path="output/my_video.avi")
+writer.start()
+for frame in frames:  # frame is a NumPy RGB array
+    writer.add_frame(frame)
+stats = writer.stop()
+print(stats)
+```
 
 ## Usage
 
@@ -86,122 +112,3 @@ This project converts any file into a video using Reed-Solomon error correction,
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-```
-```
-### 1. Install Python Dependencies
-
-#### Windows
-
-Open Command Prompt or PowerShell and run the following command:
-
-```bash
-pip install numpy pillow reedsolo tk ffmpeg-python
-```
-
-#### Linux
-
-Open the terminal and run the following command:
-```
-
-pip install numpy pillow reedsolo tk ffmpeg-python
-
-```
-
-### 2. Install ffmpeg
-
-#### Windows
-
-1. Go to the [ffmpeg download page](https://ffmpeg.org/download.html).
-2. Download the version suitable for your system.
-3. Extract the downloaded files and add the `bin` directory path to the system `PATH` environment variable.
-
-You can verify the installation by running:
-
-```bash
-ffmpeg -version
-```
-
-#### Linux
-
-Run the following commands in the terminal:
-
-```bash
-sudo apt update
-sudo apt install ffmpeg
-```
-
-You can verify the installation by running:
-
-```bash
-ffmpeg -version
-```
-
-### 3. Install CUDA and CuPy (Optional for GPU Acceleration)
-
-#### Windows
-
-1. Go to the [NVIDIA CUDA download page](https://developer.nvidia.com/cuda-downloads).
-2. Download and install the appropriate CUDA toolkit for your system.
-3. Ensure that the environment variables are correctly set (the installer usually does this automatically).
-
-Install CuPy:
-
-```bash
-pip install cupy-cudaXXX  # Replace XXX with your CUDA version, e.g., cupy-cuda112 for CUDA 11.2
-```
-
-#### Linux
-
-1. Go to the [NVIDIA CUDA download page](https://developer.nvidia.com/cuda-downloads).
-2. Download and install the appropriate CUDA toolkit for your system following the provided instructions.
-
-Install CuPy:
-
-```bash
-pip install cupy-cudaXXX  # Replace XXX with your CUDA version, e.g., cupy-cuda112 for CUDA 11.2
-```
-
-### Example Code
-
-Here is an example Python script that includes all these libraries, allowing you to verify that everything is installed correctly:
-
-```python
-import numpy as np
-import ffmpeg
-from PIL import Image, ImageDraw, ImageFont
-from reedsolo import RSCodec
-import tkinter as tk
-from tkinter import filedialog, ttk, scrolledtext
-
-try:
-    import cupy as cp
-    CUDA_ENABLED = True
-except ImportError:
-    CUDA_ENABLED = False
-
-print("All libraries imported successfully!")
-```
-
-Run this code, and if there are no errors, it means all libraries are installed correctly.
-
-### Ensuring All Libraries Are Installed
-
-You can install all the libraries in one command:
-
-#### Windows
-
-```bash
-pip install numpy pillow reedsolo tk ffmpeg-python cupy-cudaXXX
-```
-
-Replace `XXX` with your CUDA version, e.g., `cupy-cuda112`.
-
-#### Linux
-
-```bash
-pip install numpy pillow reedsolo tk ffmpeg-python cupy-cudaXXX
-```
-
-Similarly, replace `XXX` with your CUDA version, e.g., `cupy-cuda112`.
-
-If you encounter any issues, please let me know!

--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -71,4 +71,4 @@ CHUNK_SIZE = 1024 * 1024  # 1MB
 from .utils import *
 from .error_correction import ReedSolomonEncoder
 from .frame_generator import FrameGenerator
-from .encoder import VideoEncoder
+from .encoder import VideoEncoder, AviDirectWriter


### PR DESCRIPTION
## Summary
- rename `converter/init.py` to `converter/__init__.py`
- add `.gitignore`
- clean up README and add quick start and direct AVI output instructions

## Testing
- `python -m py_compile converter/*py`
